### PR TITLE
Fix too few arguments error

### DIFF
--- a/Paytm_WHMCS_v6.x_Kit-master/Paytm/gateways/callback/paytm.php
+++ b/Paytm_WHMCS_v6.x_Kit-master/Paytm/gateways/callback/paytm.php
@@ -57,7 +57,7 @@ if(isset($response['ORDERID']) && isset($response['STATUS']) && isset($response[
 		if($responseParamList['STATUS']=='TXN_SUCCESS' && $responseParamList['TXNAMOUNT']==$response['TXNAMOUNT'])
 		{
 			$gatewayresult = "success";
-			addInvoicePayment($txnid, $paytm_trans_id, $amount, $gatewaymodule); 
+			addInvoicePayment($txnid, $paytm_trans_id, $amount, 0, $gatewaymodule); 
 			logTransaction($GATEWAY["name"], $response, $response['RESPMSG']);
 		}
 		else{


### PR DESCRIPTION
AddInvoicePayment function requires a minimum of 5 arguments in the latest WHMCS. But the callback code is passing only 4 arguments, I bypassed it by adding a null value as a fifth argument.