### PR TITLE
Fix: Unique transaction ID for PayTM.

### DIFF
--- a/Paytm_WHMCS_v6.x-7.x_Kit-master/Paytm/gateways/paytm.php
+++ b/Paytm_WHMCS_v6.x-7.x_Kit-master/Paytm/gateways/paytm.php
@@ -19,7 +19,7 @@ function paytm_link($params) {
 
 	$merchant_id = $params['merchant_id'];
 	$secret_key=$params['merchant_key'];
-	$order_id = $params['invoiceid'];
+	$order_id = $params['invoiceid'].'-'.time(); // Prepare unique order id for PayTM
 	$website= $params['website'];
 	$industry_type= $params['industry_type'];
 	$channel_id="WEB";	


### PR DESCRIPTION
Unique transaction ID needed for PayTM. Timestamp added to invoice ID after '-'. This fixes #4 #5 bug in PayTM Kit.

In callback function checkCbInvoiceID() function removes timestamp automatically, so we dont need to remove it.
https://developers.whmcs.com/payment-gateways/callbacks/